### PR TITLE
FnOnce() dropfn and looser Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,12 @@ impl<T, F> Drop for Guard<T, F>
     }
 }
 
+// F might be a Fn and therefore maybe not implement Sync,
+// but a &FnMut is useless, and F is inaccessible anyway.
+unsafe impl<T, F> Sync for Guard<T, F>
+    where T: Sync, F: Send+FnMut(&mut T)
+{}
+
 #[test]
 fn test_defer() {
     use std::cell::Cell;


### PR DESCRIPTION
FnOnce costs a little performance, and it seems difficult to send an un-nameable type across threads..

What do you think?

Ill need to update documentation before this can be merged.