### PR TITLE
Add defer on unwind, defer on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ script:
       travis-cargo test &&
       travis-cargo bench &&
       travis-cargo doc
-after_success:
-  # upload the documentation (GH_TOKEN from env)
-  - travis-cargo --only nightly doc-upload
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,19 @@
 language: rust
 sudo: false
 
-# run builds for all the trains (and more)
 rust:
-  - 1.6.0
+  - 1.11.0
   - stable
   - beta
   - nightly
 
-# load travis-cargo
-before_script:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
+branches:
+  only:
+    - master
 
 # the main build
 script:
   - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo bench &&
-      travis-cargo doc
-
-env:
-  global:
-    # override the default `--features unstable` used for the nightly branch (optional)
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+      cargo build --no-default-features &&
+      cargo build &&
+      cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ even if the code between panics (assuming unwinding panic).
 """
 
 keywords = ["scope-guard", "defer", "panic"]
+
+[features]
+default = ["use_std"]
+use_std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,10 +103,16 @@ macro_rules! defer_on_unwind {
 
 /// `ScopeGuard` is a scope guard that may own a protected value.
 ///
-/// If you place a guard in a local variable, the closure will
+/// If you place a guard in a local variable, the closure can
 /// run regardless how you leave the scope — through regular return or panic
 /// (except if panic or other code aborts; so as long as destructors run).
 /// It is run only once.
+///
+/// The `S` parameter for [`Strategy`](Strategy.t.html) determines if
+/// the closure actually runs.
+///
+/// The guard's closure will be called with a mut ref to the held value
+/// in the destructor. It's called only once.
 ///
 /// The `ScopeGuard` implements `Deref` so that you can access the inner value.
 pub struct ScopeGuard<T, F, S: Strategy = Always>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,14 @@
 
 #![cfg_attr(not(any(test, feature = "use_std")), no_std)]
 
+//!
+//!
+//! Crate features:
+//!
+//! - `use_std`
+//!   + Enabled by default. Enables `OnUnwind`, `OnSuccess` strategies.
+//!   + Disable to use `no_std`.
+
 #[cfg(not(any(test, feature = "use_std")))]
 extern crate core as std;
 
@@ -23,11 +31,15 @@ pub trait Strategy {
 pub enum Always {}
 
 /// Run on scope exit through unwinding.
+///
+/// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
 #[derive(Debug)]
 pub enum OnUnwind {}
 
 /// Run on regular scope exit, when not unwinding.
+///
+/// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
 #[derive(Debug)]
 pub enum OnSuccess {}
@@ -49,7 +61,7 @@ impl Strategy for OnSuccess {
     fn should_run() -> bool { !std::thread::panicking() }
 }
 
-/// Macro to create a `ScopeGuard` (without any owned value).
+/// Macro to create a `ScopeGuard` (always run).
 ///
 /// The macro takes one expression `$e`, which is the body of a closure
 /// that will run when the scope is exited. The expression can
@@ -61,11 +73,13 @@ macro_rules! defer {
     }
 }
 
-/// Macro to create a `ScopeGuard` (without any owned value).
+/// Macro to create a `ScopeGuard` (run on successful scope exit).
 ///
 /// The macro takes one expression `$e`, which is the body of a closure
 /// that will run when the scope is exited. The expression can
 /// be a whole block.
+///
+/// Requires crate feature `use_std`.
 #[macro_export]
 macro_rules! defer_on_success {
     ($e:expr) => {
@@ -73,11 +87,13 @@ macro_rules! defer_on_success {
     }
 }
 
-/// Macro to create a `ScopeGuard` (without any owned value).
+/// Macro to create a `ScopeGuard` (run on unwinding from panic).
 ///
 /// The macro takes one expression `$e`, which is the body of a closure
 /// that will run when the scope is exited. The expression can
 /// be a whole block.
+///
+/// Requires crate feature `use_std`.
 #[macro_export]
 macro_rules! defer_on_unwind {
     ($e:expr) => {
@@ -110,6 +126,8 @@ pub fn guard<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, Always>
 
 #[cfg(feature = "use_std")]
 /// Create a new `ScopeGuard` owning `v` and with deferred closure `dropfn`.
+///
+/// Requires crate feature `use_std`.
 pub fn guard_on_success<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, OnSuccess>
     where F: FnMut(&mut T)
 {
@@ -118,6 +136,8 @@ pub fn guard_on_success<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, OnSuccess>
 
 #[cfg(feature = "use_std")]
 /// Create a new `ScopeGuard` owning `v` and with deferred closure `dropfn`.
+///
+/// Requires crate feature `use_std`.
 pub fn guard_on_unwind<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, OnUnwind>
     where F: FnMut(&mut T)
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! Crate features:
 //!
 //! - `use_std`
-//!   + Enabled by default. Enables `OnUnwind`, `OnSuccess` strategies.
+//!   + Enabled by default. Enables the `OnUnwind` strategy.
 //!   + Disable to use `no_std`.
 
 #[cfg(not(any(test, feature = "use_std")))]
@@ -42,7 +42,8 @@ pub enum OnUnwind {}
 /// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
 #[derive(Debug)]
-pub enum OnSuccess {}
+#[cfg(test)]
+enum OnSuccess {}
 
 impl Strategy for Always {
     #[inline(always)]
@@ -56,6 +57,7 @@ impl Strategy for OnUnwind {
 }
 
 #[cfg(feature = "use_std")]
+#[cfg(test)]
 impl Strategy for OnSuccess {
     #[inline(always)]
     fn should_run() -> bool { !std::thread::panicking() }
@@ -80,7 +82,7 @@ macro_rules! defer {
 /// be a whole block.
 ///
 /// Requires crate feature `use_std`.
-#[macro_export]
+#[cfg(test)]
 macro_rules! defer_on_success {
     ($e:expr) => {
         let _guard = $crate::guard_on_success((), |_| $e);
@@ -134,7 +136,8 @@ pub fn guard<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, Always>
 /// Create a new `ScopeGuard` owning `v` and with deferred closure `dropfn`.
 ///
 /// Requires crate feature `use_std`.
-pub fn guard_on_success<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, OnSuccess>
+#[cfg(test)]
+fn guard_on_success<T, F>(v: T, dropfn: F) -> ScopeGuard<T, F, OnSuccess>
     where F: FnMut(&mut T)
 {
     guard_strategy(v, dropfn)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@
 #[cfg(not(any(test, feature = "use_std")))]
 extern crate core as std;
 
-use std::ops::{Deref, DerefMut};
+use std::fmt;
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 
 pub trait Strategy {
     fn should_run() -> bool;
@@ -18,14 +19,17 @@ pub trait Strategy {
 ///
 /// Always run; with the exception of abort, process exit, and other
 /// catastrophic events.
+#[derive(Debug)]
 pub enum Always {}
 
 /// Run on scope exit through unwinding.
 #[cfg(feature = "use_std")]
+#[derive(Debug)]
 pub enum OnUnwind {}
 
 /// Run on regular scope exit, when not unwinding.
 #[cfg(feature = "use_std")]
+#[derive(Debug)]
 pub enum OnSuccess {}
 
 impl Strategy for Always {
@@ -155,6 +159,18 @@ impl<T, F, S: Strategy> Drop for Guard<T, F, S>
         if S::should_run() {
             (self.__dropfn)(&mut self.__value)
         }
+    }
+}
+
+impl<T, F, S> fmt::Debug for Guard<T, F, S>
+    where T: fmt::Debug,
+          F: FnMut(&mut T),
+          S: Strategy + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Guard")
+         .field("value", &self.__value)
+         .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,9 @@ pub trait Strategy {
 
 /// Always run on scope exit.
 ///
-/// Always run; with the exception of abort, process exit, and other
-/// catastrophic events.
+/// “Always” run: on regular exit from a scope or on unwinding from a panic.
+/// Can not run on abort, process exit, and other catastrophic events where
+/// destructors don’t run.
 #[derive(Debug)]
 pub enum Always {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,48 @@
 //! even if the code between panics.
 //! (as long as panic doesn't abort)
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "use_std")), no_std)]
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "use_std")))]
 extern crate core as std;
 
 use std::ops::{Deref, DerefMut};
+use std::marker::PhantomData;
+
+pub trait Strategy {
+    fn should_run() -> bool;
+}
+
+/// Always run on scope exit.
+///
+/// Always run; with the exception of abort, process exit, and other
+/// catastrophic events.
+pub enum Always {}
+
+/// Run on scope exit through unwinding.
+#[cfg(feature = "use_std")]
+pub enum OnUnwind {}
+
+/// Run on regular scope exit, when not unwinding.
+#[cfg(feature = "use_std")]
+pub enum OnSuccess {}
+
+impl Strategy for Always {
+    #[inline(always)]
+    fn should_run() -> bool { true }
+}
+
+#[cfg(feature = "use_std")]
+impl Strategy for OnUnwind {
+    #[inline(always)]
+    fn should_run() -> bool { std::thread::panicking() }
+}
+
+#[cfg(feature = "use_std")]
+impl Strategy for OnSuccess {
+    #[inline(always)]
+    fn should_run() -> bool { !std::thread::panicking() }
+}
 
 /// Macro to create a `Guard` (without any owned value).
 ///
@@ -21,6 +57,30 @@ macro_rules! defer {
     }
 }
 
+/// Macro to create a `Guard` (without any owned value).
+///
+/// The macro takes one expression `$e`, which is the body of a closure
+/// that will run when the scope is exited. The expression can
+/// be a whole block.
+#[macro_export]
+macro_rules! defer_on_success {
+    ($e:expr) => {
+        let _guard = $crate::guard_on_success((), |_| $e);
+    }
+}
+
+/// Macro to create a `Guard` (without any owned value).
+///
+/// The macro takes one expression `$e`, which is the body of a closure
+/// that will run when the scope is exited. The expression can
+/// be a whole block.
+#[macro_export]
+macro_rules! defer_on_unwind {
+    ($e:expr) => {
+        let _guard = $crate::guard_on_unwind((), |_| $e);
+    }
+}
+
 /// `Guard` is a scope guard that may own a protected value.
 ///
 /// If you place a guard in a local variable, the closure will
@@ -28,56 +88,126 @@ macro_rules! defer {
 /// (except if panic or other code aborts; so as long as destructors run).
 /// It is run only once.
 ///
-/// The guard's closure will be called with a mut ref to the held value;
-/// While the closure could just capture it, by placing the value in the guard
-/// the rest of the function can access it too through the `Deref` and `DerefMut` impl.
-pub struct Guard<T, F>
+/// The `Guard` implements `Deref` so that you can access the inner value.
+pub struct Guard<T, F, S: Strategy = Always>
     where F: FnMut(&mut T)
 {
     __dropfn: F,
     __value: T,
+    strategy: PhantomData<S>,
 }
 
 /// Create a new `Guard` owning `v` and with deferred closure `dropfn`.
-pub fn guard<T, F>(v: T, dropfn: F) -> Guard<T, F>
+pub fn guard<T, F>(v: T, dropfn: F) -> Guard<T, F, Always>
     where F: FnMut(&mut T)
 {
-    Guard{__value: v, __dropfn: dropfn}
+    guard_strategy(v, dropfn)
 }
 
-impl<T, F> Deref for Guard<T, F>
+#[cfg(feature = "use_std")]
+/// Create a new `Guard` owning `v` and with deferred closure `dropfn`.
+pub fn guard_on_success<T, F>(v: T, dropfn: F) -> Guard<T, F, OnSuccess>
+    where F: FnMut(&mut T)
+{
+    guard_strategy(v, dropfn)
+}
+
+#[cfg(feature = "use_std")]
+/// Create a new `Guard` owning `v` and with deferred closure `dropfn`.
+pub fn guard_on_unwind<T, F>(v: T, dropfn: F) -> Guard<T, F, OnUnwind>
+    where F: FnMut(&mut T)
+{
+    guard_strategy(v, dropfn)
+}
+
+fn guard_strategy<T, F, S: Strategy>(v: T, dropfn: F) -> Guard<T, F, S>
+    where F: FnMut(&mut T)
+{
+    Guard {
+        __value: v,
+        __dropfn: dropfn,
+        strategy: PhantomData,
+    }
+}
+
+impl<T, F, S: Strategy> Deref for Guard<T, F, S>
     where F: FnMut(&mut T)
 {
     type Target = T;
-    fn deref(&self) -> &T
-    {
+    fn deref(&self) -> &T {
         &self.__value
     }
 
 }
 
-impl<T, F> DerefMut for Guard<T, F>
+impl<T, F, S: Strategy> DerefMut for Guard<T, F, S>
     where F: FnMut(&mut T)
 {
-    fn deref_mut(&mut self) -> &mut T
-    {
+    fn deref_mut(&mut self) -> &mut T {
         &mut self.__value
     }
 }
 
-impl<T, F> Drop for Guard<T, F>
+impl<T, F, S: Strategy> Drop for Guard<T, F, S>
     where F: FnMut(&mut T)
 {
     fn drop(&mut self) {
-        (self.__dropfn)(&mut self.__value)
+        if S::should_run() {
+            (self.__dropfn)(&mut self.__value)
+        }
     }
 }
 
-#[test]
-fn test_defer() {
+#[cfg(test)]
+mod tests {
     use std::cell::Cell;
+    use std::panic::catch_unwind;
+    use std::panic::AssertUnwindSafe;
 
-    let drops = Cell::new(0);
-    defer!(drops.set(1000));
-    assert_eq!(drops.get(), 0);
+    #[test]
+    fn test_defer() {
+        let drops = Cell::new(0);
+        defer!(drops.set(1000));
+        assert_eq!(drops.get(), 0);
+    }
+
+    #[test]
+    fn test_defer_success_1() {
+        let drops = Cell::new(0);
+        {
+            defer_on_success!(drops.set(1));
+            assert_eq!(drops.get(), 0);
+        }
+        assert_eq!(drops.get(), 1);
+    }
+
+    #[test]
+    fn test_defer_success_2() {
+        let drops = Cell::new(0);
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            defer_on_success!(drops.set(1));
+            panic!("failure")
+        }));
+        assert_eq!(drops.get(), 0);
+    }
+
+    #[test]
+    fn test_defer_unwind_1() {
+        let drops = Cell::new(0);
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            defer_on_unwind!(drops.set(1));
+            assert_eq!(drops.get(), 0);
+            panic!("failure")
+        }));
+        assert_eq!(drops.get(), 1);
+    }
+
+    #[test]
+    fn test_defer_unwind_2() {
+        let drops = Cell::new(0);
+        {
+            defer_on_unwind!(drops.set(1));
+        }
+        assert_eq!(drops.get(), 0);
+    }
 }


### PR DESCRIPTION
Add scope guards that run depending on the state of `std::thread::panicking`.

- `defer_on_unwind`
- `defer_on_success`

This requires libstd, unfortunately, but the regular ("always run") `defer` is still libcore compatible.