### PR TITLE
Zero-cost FnOnce(T)   (and more)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-  - 1.11.0
+  - 1.20.0
   - stable
   - beta
   - nightly
@@ -16,4 +16,4 @@ script:
   - |
       cargo build --no-default-features &&
       cargo build &&
-      ([ "$TRAVIS_RUST_VERSION" != "1.11.0" ] && cargo test ) || cargo test --lib
+      cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.3.3"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/bluss/scopeguard"
 documentation = "https://docs.rs/scopeguard/"
+readme = "README.rst"
 authors = ["bluss"]
 
 description = """
@@ -15,8 +16,8 @@ Defines the macros `defer!` and `defer_on_unwind!`; the latter only runs
 if the scope is exited through unwinding on panic.
 """
 
-keywords = ["scope-guard", "defer", "panic"]
-categories = ["rust-patterns"]
+keywords = ["scope-guard", "defer", "panic", "unwind"]
+categories = ["rust-patterns", "no-std"]
 
 [features]
 default = ["use_std"]

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ How to use
             let _ = f.sync_all();
         });
         // Access the file through the scope guard itself
-        file.write(b"test me\n").unwrap();
+        file.write_all(b"test me\n").unwrap();
     }
 
 Recent Changes

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ it goes out of scope, even if the code between panics (assuming unwinding panic)
 The `defer!` macro and `guard` are `no_std` compatible (require only core),
 but the on unwinding strategy requires linking to `std`.
 
-Requires Rust 1.11.
+Requires Rust 1.20.
 
 
 Please read the `API documentation here`__

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Rust crate for a convenient RAII scope guard that will run a given closure when
 it goes out of scope, even if the code between panics (assuming unwinding panic).
 
 The `defer!` macro and `guard` are `no_std` compatible (require only core),
-but the on unwinding strategy requires linking to `std`.
+but the on unwinding / not on uwinding strategies requires linking to `std`.
 
 Requires Rust 1.20.
 

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -18,7 +18,7 @@ fn g() {
         let _ = f.sync_all();
     });
     // Access the file through the scope guard itself
-    file.write(b"test me\n").unwrap();
+    file.write_all(b"test me\n").unwrap();
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(any(test, feature = "use_std")), no_std)]
+#![cfg_attr(feature="cargo-clippy", allow(inline_always))]
 
 //! A scope guard will run a given closure when it goes out of scope,
 //! even if the code between panics.
@@ -61,7 +62,7 @@
 //!         let _ = f.sync_all();
 //!     });
 //!     // Access the file through the scope guard itself
-//!     file.write(b"test me\n").map(|_| ())
+//!     file.write_all(b"test me\n").map(|_| ())
 //! }
 //!
 //! fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,11 @@ pub fn guard_on_unwind<T, F: FnOnce(T)>(v: T, dropfn: F)
     ScopeGuard::with_strategy(v, dropfn)
 }
 
+// ScopeGuard can be Sync even if F isn't because the closure is
+// not accessible from references.
+// The guard does not store any instance of S, so it is also irellevant.
+unsafe impl<T: Sync, F: FnOnce(T), S: Strategy> Sync for ScopeGuard<T, F, S> {}
+
 impl<T, F: FnOnce(T), S: Strategy> Deref for ScopeGuard<T, F, S> {
     type Target = T;
     fn deref(&self) -> &T {


### PR DESCRIPTION
When you said that my [previous attempt at `FnOnce(T)`](#9) affects all current users (who don't need it),
I assume it was the overhead (of wrapping `T` and `F` in `Option`) you were refering to.
This became possible without overhead after the stabilization of `ManuallyDrop`, albeit with a bit of unsafe.  
Apart from allowing the guard to do more things, `FnOnce` will also be [less suprising](#15).

Since this requires a major version bump, what do you think about making a 1.0 release? the last commit was 10 months ago.  
I have a [1.0 commit](https://github.com/tormol/scopeguard/tree/7b9d7d13d30a66f27e3fdbbd7d7c226b88e94642) that also includes a Rust version policy based on `indexmap`'s, but slightly stricter.  
(Of the 16 reverse dependencies on crates.io, only one (autopilot) [breaks](https://github.com/autopilot-rs/autopilot-rs/blob/95801a0a2aab57a8f79f97fcf178fd7c7e348149/src/bitmap.rs#L509) when forced to use a `FnOnce(T)` version, so upgrading should be trivial for most users)

Adding this crate to the "no_std" category should be fine as there are many crates in that category which are only optionally `#![no_std]`.

My motivation for the other (non-breaking) features is "because we can", and that they should not negatively affect anyone.  
(`defer_on_success!{}` / `guard_on_success()` already existed and were documented, so why not expose them?)

Feel free to cherry-pick.