### PR TITLE
Change macros to accept statements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 
 license = "MIT/Apache-2.0"
 repository = "https://github.com/bluss/scopeguard"

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ How to use
 Recent Changes
 --------------
 
+- 1.1.0
+
+  - Change macros (``defer!``, ``defer_on_success!`` and ``defer_on_unwind!``)
+    to accept statements. (by @konsumlamm)
+
 - 1.0.0
 
   - Change the closure type from ``FnMut(&mut T)`` to ``FnOnce(T)``:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ impl Strategy for OnSuccess {
 ///
 /// The macro takes statements, which are the body of a closure
 /// that will run when the scope is exited.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! defer {
     ($($t:tt)*) => {
         let _guard = $crate::guard((), |()| { $($t)* });
@@ -261,7 +261,7 @@ macro_rules! defer {
 ///
 /// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! defer_on_success {
     ($($t:tt)*) => {
         let _guard = $crate::guard_on_success((), |()| { $($t)* });
@@ -275,7 +275,7 @@ macro_rules! defer_on_success {
 ///
 /// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! defer_on_unwind {
     ($($t:tt)*) => {
         let _guard = $crate::guard_on_unwind((), |()| { $($t)* });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,20 +243,6 @@ impl Strategy for OnSuccess {
     fn should_run() -> bool { !std::thread::panicking() }
 }
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __defer_internal {
-    (@defer $b:block) => {
-        let _guard = $crate::guard((), |()| $b);
-    };
-    (@defer_on_success $b:block) => {
-        let _guard = $crate::guard_on_success((), |()| $b);
-    };
-    (@defer_on_unwind $b:block) => {
-        let _guard = $crate::guard_on_unwind((), |()| $b);
-    };
-}
-
 /// Macro to create a `ScopeGuard` (always run).
 ///
 /// The macro takes statements, which are the body of a closure
@@ -264,7 +250,7 @@ macro_rules! __defer_internal {
 #[macro_export(local_inner_macros)]
 macro_rules! defer {
     ($($t:tt)*) => {
-        __defer_internal!(@defer { $($t)* })
+        let _guard = $crate::guard((), |()| { $($t)* });
     };
 }
 
@@ -278,7 +264,7 @@ macro_rules! defer {
 #[macro_export(local_inner_macros)]
 macro_rules! defer_on_success {
     ($($t:tt)*) => {
-        __defer_internal!(@defer_on_success { $($t)* })
+        let _guard = $crate::guard_on_success((), |()| { $($t)* });
     };
 }
 
@@ -292,7 +278,7 @@ macro_rules! defer_on_success {
 #[macro_export(local_inner_macros)]
 macro_rules! defer_on_unwind {
     ($($t:tt)*) => {
-        __defer_internal!(@defer_on_unwind { $($t)* })
+        let _guard = $crate::guard_on_unwind((), |()| { $($t)* });
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@
 //!     let drop_counter = Cell::new(0);
 //!     {
 //!         // Create a scope guard using `defer!` for the current scope
-//!         defer! {{
+//!         defer! {
 //!             drop_counter.set(1 + drop_counter.get());
-//!         }};
+//!         }
 //!
 //!         // Do regular operations here in the meantime.
 //!
@@ -245,21 +245,22 @@ impl Strategy for OnSuccess {
 
 /// Macro to create a `ScopeGuard` (always run).
 ///
-/// The macro takes one expression `$e`, which is the body of a closure
-/// that will run when the scope is exited. The expression can
-/// be a whole block.
+/// The macro takes statements, which are the body of a closure
+/// that will run when the scope is exited.
 #[macro_export]
 macro_rules! defer {
-    ($e:expr) => {
-        let _guard = $crate::guard((), |()| $e);
-    }
+    (@block $b:expr) => {
+        let _guard = $crate::guard((), |()| $b);
+    };
+    ($($t:tt)*) => {
+        defer!(@block { $($t)* })
+    };
 }
 
 /// Macro to create a `ScopeGuard` (run on successful scope exit).
 ///
-/// The macro takes one expression `$e`, which is the body of a closure
-/// that will run when the scope is exited. The expression can
-/// be a whole block.
+/// The macro takes statements, which are the body of a closure
+/// that will run when the scope is exited.
 ///
 /// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
@@ -267,14 +268,16 @@ macro_rules! defer {
 macro_rules! defer_on_success {
     ($e:expr) => {
         let _guard = $crate::guard_on_success((), |()| $e);
-    }
+    };
+    ($($t:tt)*) => {
+        defer_on_success!(@block { $($t)* })
+    };
 }
 
 /// Macro to create a `ScopeGuard` (run on unwinding from panic).
 ///
-/// The macro takes one expression `$e`, which is the body of a closure
-/// that will run when the scope is exited. The expression can
-/// be a whole block.
+/// The macro takes statements, which are the body of a closure
+/// that will run when the scope is exited.
 ///
 /// Requires crate feature `use_std`.
 #[cfg(feature = "use_std")]
@@ -282,7 +285,10 @@ macro_rules! defer_on_success {
 macro_rules! defer_on_unwind {
     ($e:expr) => {
         let _guard = $crate::guard_on_unwind((), |()| $e);
-    }
+    };
+    ($($t:tt)*) => {
+        defer_on_unwind!(@block { $($t)* })
+    };
 }
 
 /// `ScopeGuard` is a scope guard that may own a protected value.


### PR DESCRIPTION
This commit changes the macros (defer, defer_on_success and defer_on_unwind) to
accept statements instead of just an expression. That makes it more convenient to write something like this (which previously required double braces):
```rust
defer! {
    let a = 42;
    println!("The number is {}., a);
}
```
I updated the version to "1.1.0", since this adds functionality in a sense. If you have any issues, please let me know.