### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,13 +22,19 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Check formatting
-        run: cargo fmt -- --check
       - name: Build
         run: cargo build
       - name: Run tests
         run: cargo test
       - name: Run tests (no_std)
         run: cargo test --no-default-features
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check


### PR DESCRIPTION
Followup to #32.

Move formatting checking to its own job, since `cargo fmt` is only available on stable.