### PR TITLE
Fix aliasing in sort doctest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@
 //!             if *hole_guard.value >= hole_guard.v[i] {
 //!                 // move the element back and the hole forward
 //!                 let index = hole_guard.index;
-//!                 ptr::copy_nonoverlapping(&hole_guard.v[index + 1], &mut hole_guard.v[index], 1);
+//!                 hole_guard.v.swap(index, index + 1);
 //!                 hole_guard.index += 1;
 //!             } else {
 //!                 break;


### PR DESCRIPTION
In Stacked Borrows 2.1, the existing code is UB because the second argument does mutable indexing into a slice, which mutably borrows the entire contents of the slice and thus invalidates all pointers into it. This can be detected by running `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test`.

Fortunately there is a safe API for the operation we need here, so we can use it and not even worry about what exactly the aliasing model is.

Since this is just a test it's not an issue for users of this crate, but I think doctests have considerable pedagogical value :)