### PR TITLE
Add support for building as a dependency of std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,15 @@ shorthands for guards with one of the implemented strategies.
 keywords = ["scope-guard", "defer", "panic", "unwind"]
 categories = ["rust-patterns", "no-std"]
 
+[dependencies]
+# Special dependencies used in rustc-dep-of-std mode.
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = '0.1.49', optional = true }
+
 [features]
 default = ["use_std"]
 use_std = []
+rustc-dep-of-std = ["core", "compiler_builtins"]
 
 [package.metadata.release]
 no-dev-version = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,7 +483,7 @@ where
     F: FnOnce(T),
     S: Strategy,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct(stringify!(ScopeGuard))
             .field("value", &*self.value)
             .finish()


### PR DESCRIPTION
Add an optional "rustc-dep-of-std" feature which, when enabled, enables
support for the special dependencies that allow this library to be used
as a dependency of std.

Very few users will want to use this, however I am experimenting with
some changes in [mustang] where having this feature in scopeguard would
be useful.

This also includes a minor warning fix that comes up in the std build.

[mustang]: https://github.com/sunfishcode/mustang